### PR TITLE
空ロググループの扱いの変更

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,3 +18,6 @@ rules:
     - error
     - ignorePackages
     - ts: never
+  no-unused-vars: off
+  '@typescript-eslint/no-unused-vars':
+    - error

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -28,4 +28,4 @@ jobs:
           role-session-name: CleanCloudwatchLogs
       - name: deploy
         if: startsWith(github.ref, 'refs/heads/main')
-        run: npm run deploy
+        run: npm run deploy -- -c queue_arn=${{ secrets.QUEUE_ARN }}

--- a/bin/clean_cloudwatch_logs.ts
+++ b/bin/clean_cloudwatch_logs.ts
@@ -4,7 +4,13 @@ import * as cdk from 'aws-cdk-lib';
 import { CleanCloudwatchLogsStack } from '../lib/clean_cloudwatch_logs-stack';
 
 const app = new cdk.App();
+const queueArn = app.node.tryGetContext('queue_arn');
+
 /* eslint-disable no-new */
-new CleanCloudwatchLogsStack(app, 'CleanCloudwatchLogsStack-ap-northeast-1', { env: { region: 'ap-northeast-1' } });
-new CleanCloudwatchLogsStack(app, 'CleanCloudwatchLogsStack-us-east-1', { env: { region: 'us-east-1' } });
+new CleanCloudwatchLogsStack(app, 'CleanCloudwatchLogsStack-ap-northeast-1', {
+  env: { region: 'ap-northeast-1' }, queueArn,
+});
+new CleanCloudwatchLogsStack(app, 'CleanCloudwatchLogsStack-us-east-1', {
+  env: { region: 'us-east-1' }, queueArn,
+});
 /* eslint-enable no-new */

--- a/lib/clean_cloudwatch_logs-stack.delete_log_streams.ts
+++ b/lib/clean_cloudwatch_logs-stack.delete_log_streams.ts
@@ -3,6 +3,7 @@ import {
   CloudWatchLogsClient, DeleteLogStreamCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
 import { LogStreamInfoType, isLogStreamInfoType } from './common_types';
+import { isObject, isString } from './type_utils';
 
 type InputType = {
   logGroupName: string,
@@ -17,17 +18,17 @@ const client = AWSXRay.captureAWSv3Client(
   }),
 );
 
-function isInputType(arg: any): arg is InputType {
+function isInputType(arg: unknown): arg is InputType {
   return (
-    arg != null
-    && typeof arg.logGroupName === 'string'
+    isObject<InputType>(arg)
+    && isString(arg.logGroupName)
     && Array.isArray(arg.targetLogStreams)
     && arg.targetLogStreams.every(isLogStreamInfoType)
   );
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export async function handler(input: any): Promise<OutputType> {
+export async function handler(input: unknown): Promise<OutputType> {
   const startTime = Date.now();
 
   if (!isInputType(input)) {

--- a/lib/clean_cloudwatch_logs-stack.get_log_groups.ts
+++ b/lib/clean_cloudwatch_logs-stack.get_log_groups.ts
@@ -6,7 +6,6 @@ type OutputType = {
   eventTime: number,
   targetLogGroups: LogGroupInfoType[],
   noRetentionLogGroups: LogGroupInfoType[],
-  emptyLogGroups: LogGroupInfoType[],
 }
 
 const client = new CloudWatchLogsClient({ maxAttempts: 5 });
@@ -18,7 +17,6 @@ export async function handler(time: unknown): Promise<OutputType> {
       eventTime: 0,
       targetLogGroups: [],
       noRetentionLogGroups: [],
-      emptyLogGroups: [],
     };
   }
 
@@ -26,7 +24,6 @@ export async function handler(time: unknown): Promise<OutputType> {
   const thresholdTimeEpoch = eventTime - 7 * 24 * 60 * 60 * 1000;
   const targetLogGroups: LogGroupInfoType[] = [];
   const noRetentionLogGroups: LogGroupInfoType[] = [];
-  const emptyLogGroups: LogGroupInfoType[] = [];
 
   // eslint-disable-next-line no-restricted-syntax
   for await (const page of paginateDescribeLogGroups({ client }, {})) {
@@ -48,8 +45,6 @@ export async function handler(time: unknown): Promise<OutputType> {
 
       if (logGroup.retentionInDays == null) {
         logGroups = noRetentionLogGroups;
-      } else if (logGroup.storedBytes === 0) {
-        logGroups = emptyLogGroups;
       } else {
         logGroups = targetLogGroups;
       }
@@ -62,6 +57,5 @@ export async function handler(time: unknown): Promise<OutputType> {
     eventTime,
     targetLogGroups,
     noRetentionLogGroups,
-    emptyLogGroups,
   };
 }

--- a/lib/clean_cloudwatch_logs-stack.get_log_groups.ts
+++ b/lib/clean_cloudwatch_logs-stack.get_log_groups.ts
@@ -1,5 +1,6 @@
 import { CloudWatchLogsClient, paginateDescribeLogGroups } from '@aws-sdk/client-cloudwatch-logs';
 import { LogGroupInfoType } from './common_types';
+import { isString } from './type_utils';
 
 type OutputType = {
   eventTime: number,
@@ -11,8 +12,8 @@ type OutputType = {
 const client = new CloudWatchLogsClient({ maxAttempts: 5 });
 
 // eslint-disable-next-line import/prefer-default-export
-export async function handler(time: any): Promise<OutputType> {
-  if (typeof time !== 'string') {
+export async function handler(time: unknown): Promise<OutputType> {
+  if (!isString(time)) {
     return {
       eventTime: 0,
       targetLogGroups: [],

--- a/lib/clean_cloudwatch_logs-stack.get_log_streams.ts
+++ b/lib/clean_cloudwatch_logs-stack.get_log_streams.ts
@@ -11,6 +11,7 @@ type InputType = {
 type OutputType = {
   logGroupName: string,
   targetLogStreams: LogStreamInfoType[];
+  isEmpty: boolean;
 }
 
 const client = AWSXRay.captureAWSv3Client(
@@ -33,6 +34,7 @@ export async function handler(input: unknown): Promise<OutputType> {
     return {
       logGroupName: '',
       targetLogStreams: [],
+      isEmpty: false,
     };
   }
 
@@ -45,15 +47,21 @@ export async function handler(input: unknown): Promise<OutputType> {
     return {
       logGroupName: '',
       targetLogStreams: [],
+      isEmpty: false,
     };
   }
 
   const targetLogStreams: LogStreamInfoType[] = [];
+  let isEmpty = true;
 
   // eslint-disable-next-line no-restricted-syntax
   for await (const page of paginateDescribeLogStreams({ client }, {
     logGroupName,
   })) {
+    if (page.logStreams != null && page.logStreams.length > 0) {
+      isEmpty = false;
+    }
+
     page.logStreams?.forEach((logStream) => {
       if (logStream.logStreamName == null) {
         return;
@@ -78,5 +86,6 @@ export async function handler(input: unknown): Promise<OutputType> {
   return {
     logGroupName,
     targetLogStreams,
+    isEmpty,
   };
 }

--- a/lib/clean_cloudwatch_logs-stack.get_log_streams.ts
+++ b/lib/clean_cloudwatch_logs-stack.get_log_streams.ts
@@ -1,6 +1,7 @@
 import * as AWSXRay from 'aws-xray-sdk';
 import { CloudWatchLogsClient, paginateDescribeLogStreams } from '@aws-sdk/client-cloudwatch-logs';
 import { LogStreamInfoType, isLogGroupInfoType, LogGroupInfoType } from './common_types';
+import { isObject, isNumber } from './type_utils';
 
 type InputType = {
   eventTime: number;
@@ -18,16 +19,16 @@ const client = AWSXRay.captureAWSv3Client(
   }),
 );
 
-function isInputType(arg: any): arg is InputType {
+function isInputType(arg: unknown): arg is InputType {
   return (
-    arg != null
-    && typeof arg.eventTime === 'number'
+    isObject<InputType>(arg)
+    && isNumber(arg.eventTime)
     && isLogGroupInfoType(arg.logGroupInfo)
   );
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export async function handler(input: any): Promise<OutputType> {
+export async function handler(input: unknown): Promise<OutputType> {
   if (!isInputType(input)) {
     return {
       logGroupName: '',

--- a/lib/common_types.ts
+++ b/lib/common_types.ts
@@ -1,22 +1,24 @@
+import { isObject, isString, isNumber } from './type_utils';
+
 export type LogGroupInfoType = {
   name: string;
   retentionInDays?: number;
 }
 
-export function isLogGroupInfoType(arg: any): arg is LogGroupInfoType {
+export function isLogGroupInfoType(arg: unknown): arg is LogGroupInfoType {
   return (
-    arg != null
-    && typeof arg.name === 'string'
-    && (arg.retentionInDays == null || typeof arg.retentionInDays === 'number'));
+    isObject<LogGroupInfoType>(arg)
+    && isString(arg.name)
+    && (arg.retentionInDays == null || isNumber(arg.retentionInDays)));
 }
 
 export type LogStreamInfoType = {
   name: string;
 }
 
-export function isLogStreamInfoType(arg: any): arg is LogStreamInfoType {
+export function isLogStreamInfoType(arg: unknown): arg is LogStreamInfoType {
   return (
-    arg != null
-    && typeof arg.name === 'string'
+    isObject<LogStreamInfoType>(arg)
+    && isString(arg.name)
   );
 }

--- a/lib/type_utils.ts
+++ b/lib/type_utils.ts
@@ -1,0 +1,16 @@
+// https://qiita.com/suin/items/e0f7b7add75092196cd8 を参考にした、
+// 型ガード関数のヘルパ処理
+type WouldBe<T> = { [P in keyof T]?: unknown }
+
+// eslint-disable-next-line import/prefer-default-export
+export function isObject<T extends object>(value: unknown): value is WouldBe<T> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number';
+}
+
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}


### PR DESCRIPTION
これまで、全てのログストリームが空になったロググループは無操作の対象だったが、以下に変更する。

- 空のログストリームは削除する
- ログストリームを含まなくなったロググループはSQSにメッセージを送ることで、管理者に通知する

加えて、このタイミングで、リファクタリングを行う。