### PR TITLE
スタック全体にタグを付与する

### DIFF
--- a/lib/clean_cloudwatch_logs-stack.ts
+++ b/lib/clean_cloudwatch_logs-stack.ts
@@ -26,6 +26,10 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
   constructor (scope: construct.Construct, id: string, props: StackProps) {
     super(scope, id, props)
 
+    cdk.Tags.of(this).add('Project', 'clean_cloudwatch_logs')
+    cdk.Tags.of(this).add('Env', 'prod')
+    cdk.Tags.of(this).add('ManagedBy', 'cdk')
+
     const getLogGroupsLambda = new lambdaNodejs.NodejsFunction(this, 'get_log_groups', {
       architecture: lambda.Architecture.ARM_64,
       timeout: cdk.Duration.minutes(1),

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -29,6 +29,20 @@ exports[`snapshot test 1`] = `
           ],
         },
         "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -58,6 +72,20 @@ exports[`snapshot test 1`] = `
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
               ],
             ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
           },
         ],
       },
@@ -127,6 +155,20 @@ exports[`snapshot test 1`] = `
           ],
           "Version": "2012-10-17",
         },
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
       },
       "Type": "AWS::IAM::Role",
     },
@@ -214,6 +256,20 @@ exports[`snapshot test 1`] = `
             "Arn",
           ],
         },
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
       },
       "Type": "AWS::StepFunctions::StateMachine",
       "UpdateReplacePolicy": "Delete",
@@ -232,6 +288,20 @@ exports[`snapshot test 1`] = `
           ],
           "Version": "2012-10-17",
         },
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
       },
       "Type": "AWS::IAM::Role",
     },
@@ -388,6 +458,20 @@ exports[`snapshot test 1`] = `
           ],
         },
         "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
         "Timeout": 900,
         "TracingConfig": {
           "Mode": "Active",
@@ -421,6 +505,20 @@ exports[`snapshot test 1`] = `
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
               ],
             ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
           },
         ],
       },
@@ -478,6 +576,20 @@ exports[`snapshot test 1`] = `
           ],
         },
         "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
         "Timeout": 60,
         "TracingConfig": {
           "Mode": "Active",
@@ -511,6 +623,20 @@ exports[`snapshot test 1`] = `
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
               ],
             ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
           },
         ],
       },
@@ -568,6 +694,20 @@ exports[`snapshot test 1`] = `
           ],
         },
         "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
         "Timeout": 300,
         "TracingConfig": {
           "Mode": "Active",
@@ -630,6 +770,20 @@ exports[`snapshot test 1`] = `
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
               ],
             ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
           },
         ],
       },

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib'
-import { Template } from 'aws-cdk-lib/assertions'
+import { Match, Template } from 'aws-cdk-lib/assertions'
 import { CleanCloudwatchLogsStack } from '../lib/clean_cloudwatch_logs-stack'
 
 export const ignoreAssetHashSerializer = {
@@ -18,10 +18,21 @@ test('snapshot test', () => {
     env: { region: 'ap-northeast-1' }, queueArn,
   })
   // スタックからテンプレート(JSON)を生成
-  const template = Template.fromStack(stack).toJSON()
+  const template = Template.fromStack(stack)
+
+  const expectedTags = [
+    { Key: 'Project', Value: 'clean_cloudwatch_logs' },
+    { Key: 'Env', Value: 'prod' },
+    { Key: 'ManagedBy', Value: 'cdk' },
+  ]
+  for (const tag of expectedTags) {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Tags: Match.arrayWith([tag]),
+    })
+  }
 
   expect.addSnapshotSerializer(ignoreAssetHashSerializer)
 
   // 生成したテンプレートとスナップショットが同じか検証
-  expect(template).toMatchSnapshot()
+  expect(template.toJSON()).toMatchSnapshot()
 })


### PR DESCRIPTION
## Summary
- `CleanCloudwatchLogsStack` のコンストラクタで `Tags.of(this)` を使い、スタック内のタグ対応リソース全体に共通タグを一括適用する
- 付与するタグ: `Project=clean_cloudwatch_logs`, `Env=prod`, `ManagedBy=cdk`
- スナップショットテストにタグのアサーションを追加し、テンプレートのスナップショットを更新する

## Test plan
- [x] `npm test` がパスすること
- [x] `cdk deploy` 後、Lambda / IAM / Step Functions 等のリソースにタグが付与されていることを AWS コンソールで確認する


Made with [Cursor](https://cursor.com)