### PR TITLE
空LogGroupの通知をSQS 1件に集約し、CloudWatch Logsリンクを追加

### DIFF
--- a/lib/clean_cloudwatch_logs-stack.build_notify_message.ts
+++ b/lib/clean_cloudwatch_logs-stack.build_notify_message.ts
@@ -1,0 +1,55 @@
+import { isObject, isString } from './type_utils'
+
+type GetLogStreamsResultType = {
+  logGroupName: string;
+  isEmpty: boolean;
+  region: string;
+}
+
+type InputType = {
+  getLogStreamsResults: GetLogStreamsResultType[];
+}
+
+type OutputType = {
+  notifyMessage: string;
+}
+
+function isGetLogStreamsResultType (arg: unknown): arg is GetLogStreamsResultType {
+  return (
+    isObject<GetLogStreamsResultType>(arg) &&
+    isString(arg.logGroupName) &&
+    typeof arg.isEmpty === 'boolean' &&
+    isString(arg.region)
+  )
+}
+
+function isInputType (arg: unknown): arg is InputType {
+  return (
+    isObject<InputType>(arg) &&
+    Array.isArray(arg.getLogStreamsResults) &&
+    arg.getLogStreamsResults.every(isGetLogStreamsResultType)
+  )
+}
+
+export function buildNotifyMessageLine (region: string, logGroupName: string): string {
+  return `Region: ${region}, Loggroup: ${logGroupName} is empty.`
+}
+
+export function buildCloudWatchLogsUrl (region: string): string {
+  return `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logsV2:log-groups`
+}
+
+export async function handler (input: unknown): Promise<OutputType> {
+  if (!isInputType(input)) {
+    return { notifyMessage: '' }
+  }
+
+  const emptyResults = input.getLogStreamsResults.filter((result) => result.isEmpty)
+  const lines = emptyResults.map((result) => buildNotifyMessageLine(result.region, result.logGroupName))
+
+  return {
+    notifyMessage: lines.length > 0
+      ? `${lines.join('\n')}\n${buildCloudWatchLogsUrl(emptyResults[0].region)}`
+      : '',
+  }
+}

--- a/lib/clean_cloudwatch_logs-stack.ts
+++ b/lib/clean_cloudwatch_logs-stack.ts
@@ -77,10 +77,19 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
       payloadResponseOnly: true,
     })
 
-    const notifyMessage = new tasks.EvaluateExpression(this, 'NotifyMessage', {
-      // eslint-disable-next-line no-template-curly-in-string
-      expression: '`Region: ${$.region}, Loggroup: ${$.logGroupName} is empty.`',
-      resultPath: '$.notifyMessage',
+    const buildNotifyMessageLambda = new lambdaNodejs.NodejsFunction(this, 'build_notify_message', {
+      architecture: lambda.Architecture.ARM_64,
+      timeout: cdk.Duration.seconds(30),
+      tracing: lambda.Tracing.ACTIVE,
+      runtime: lambda.Runtime.NODEJS_22_X,
+    })
+
+    const buildNotifyMessage = new tasks.LambdaInvoke(this, 'BuildNotifyMessage', {
+      lambdaFunction: buildNotifyMessageLambda,
+      payload: sfn.TaskInput.fromObject({
+        getLogStreamsResults: sfn.JsonPath.listAt('$.getLogStreamsResults'),
+      }),
+      payloadResponseOnly: true,
     })
 
     const notifyEmptyLogGroup = new tasks.SqsSendMessage(this, 'NotifyEmptyLogGroup', {
@@ -91,6 +100,17 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
       }),
     })
 
+    const skipNotify = new sfn.Pass(this, 'SkipNotify')
+
+    const hasEmptyLogGroups = new sfn.Choice(this, 'HasEmptyLogGroups')
+      .when(
+        sfn.Condition.stringGreaterThan('$.notifyMessage', ''),
+        notifyEmptyLogGroup
+      )
+      .otherwise(skipNotify)
+
+    const emptyLogGroup = new sfn.Pass(this, 'EmptyLogGroup')
+
     const getLogStreamsMap = new sfn.Map(this, 'GetLogStreamsMap', {
       itemsPath: sfn.JsonPath.stringAt('$.targetLogGroups'),
       itemSelector: {
@@ -98,7 +118,7 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
         'logGroupInfo.$': '$$.Map.Item.Value',
       },
       maxConcurrency: 1,
-      resultPath: sfn.JsonPath.DISCARD,
+      resultPath: '$.getLogStreamsResults',
     })
 
     const setRetention = new tasks.CallAwsService(this, 'SetRetentionInDays', {
@@ -129,10 +149,10 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
         new sfn.Choice(this, 'IsEmptyLogGroup')
           .when(
             sfn.Condition.booleanEquals('$.isEmpty', true),
-            notifyMessage.next(notifyEmptyLogGroup)
+            emptyLogGroup
           )
           .otherwise(deleteLogStreams)
-      )),
+      )).next(buildNotifyMessage).next(hasEmptyLogGroups),
       setRetentionMap.itemProcessor(setRetention)
     )
 

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -10,59 +10,6 @@ exports[`snapshot test 1`] = `
     },
   },
   "Resources": {
-    "Eval41256dc5445742738ed917bc818694e54EB1134F": {
-      "DependsOn": [
-        "Eval41256dc5445742738ed917bc818694e5ServiceRoleA1AB6027",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
-          },
-          "S3Key": "HASH-REPLACED.zip",
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "Eval41256dc5445742738ed917bc818694e5ServiceRoleA1AB6027",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs22.x",
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "Eval41256dc5445742738ed917bc818694e5ServiceRoleA1AB6027": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "Schedule83A77FD1": {
       "Properties": {
         "FlexibleTimeWindow": {
@@ -171,28 +118,28 @@ exports[`snapshot test 1`] = `
                   "Arn",
                 ],
               },
-              ""},"ParallelLogGroups":{"Type":"Parallel","End":true,"Branches":[{"StartAt":"GetLogStreamsMap","States":{"GetLogStreamsMap":{"Type":"Map","ResultPath":null,"End":true,"ItemsPath":"$.targetLogGroups","ItemSelector":{"eventTime.$":"$.eventTime","logGroupInfo.$":"$$.Map.Item.Value"},"ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"GetLogStreams","States":{"GetLogStreams":{"Next":"IsEmptyLogGroup","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"",
+              ""},"ParallelLogGroups":{"Type":"Parallel","End":true,"Branches":[{"StartAt":"GetLogStreamsMap","States":{"GetLogStreamsMap":{"Type":"Map","ResultPath":"$.getLogStreamsResults","Next":"BuildNotifyMessage","ItemsPath":"$.targetLogGroups","ItemSelector":{"eventTime.$":"$.eventTime","logGroupInfo.$":"$$.Map.Item.Value"},"ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"GetLogStreams","States":{"GetLogStreams":{"Next":"IsEmptyLogGroup","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"",
               {
                 "Fn::GetAtt": [
                   "getlogstreamsD20145F9",
                   "Arn",
                 ],
               },
-              ""},"IsEmptyLogGroup":{"Type":"Choice","Choices":[{"Variable":"$.isEmpty","BooleanEquals":true,"Next":"NotifyMessage"}],"Default":"DeleteLogStreams"},"DeleteLogStreams":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"",
+              ""},"IsEmptyLogGroup":{"Type":"Choice","Choices":[{"Variable":"$.isEmpty","BooleanEquals":true,"Next":"EmptyLogGroup"}],"Default":"DeleteLogStreams"},"DeleteLogStreams":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"",
               {
                 "Fn::GetAtt": [
                   "deletelogstreams9F60BE28",
                   "Arn",
                 ],
               },
-              ""},"NotifyMessage":{"Next":"NotifyEmptyLogGroup","Type":"Task","ResultPath":"$.notifyMessage","Resource":"",
+              ""},"EmptyLogGroup":{"Type":"Pass","End":true}}},"MaxConcurrency":1},"BuildNotifyMessage":{"Next":"HasEmptyLogGroups","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"",
               {
                 "Fn::GetAtt": [
-                  "Eval41256dc5445742738ed917bc818694e54EB1134F",
+                  "buildnotifymessageE60281A8",
                   "Arn",
                 ],
               },
-              "","Parameters":{"expression":"\`Region: \${$.region}, Loggroup: \${$.logGroupName} is empty.\`","expressionAttributeValues":{"$.region.$":"$.region","$.logGroupName.$":"$.logGroupName"}}},"NotifyEmptyLogGroup":{"End":true,"Type":"Task","Resource":"arn:",
+              "","Parameters":{"getLogStreamsResults.$":"$.getLogStreamsResults"}},"HasEmptyLogGroups":{"Type":"Choice","Choices":[{"Variable":"$.notifyMessage","StringGreaterThan":"","Next":"NotifyEmptyLogGroup"}],"Default":"SkipNotify"},"SkipNotify":{"Type":"Pass","End":true},"NotifyEmptyLogGroup":{"End":true,"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -200,7 +147,7 @@ exports[`snapshot test 1`] = `
               {
                 "Ref": "AWS::URLSuffix",
               },
-              "/123456789012/Queue","MessageBody":{"webhookname":"Develop","message.$":"$.notifyMessage"}}}}},"MaxConcurrency":1}}},{"StartAt":"SetRetentionMap","States":{"SetRetentionMap":{"Type":"Map","ResultPath":null,"End":true,"ItemsPath":"$.noRetentionLogGroups","ItemSelector":{"logGroupInfo.$":"$$.Map.Item.Value"},"ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"SetRetentionInDays","States":{"SetRetentionInDays":{"End":true,"Retry":[{"ErrorEquals":["CloudWatchLogs.CloudWatchLogsException","CloudWatchLogs.SdkClientException"],"IntervalSeconds":1,"MaxAttempts":5,"BackoffRate":2}],"Type":"Task","ResultPath":null,"Resource":"arn:",
+              "/123456789012/Queue","MessageBody":{"webhookname":"Develop","message.$":"$.notifyMessage"}}}}},{"StartAt":"SetRetentionMap","States":{"SetRetentionMap":{"Type":"Map","ResultPath":null,"End":true,"ItemsPath":"$.noRetentionLogGroups","ItemSelector":{"logGroupInfo.$":"$$.Map.Item.Value"},"ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"SetRetentionInDays","States":{"SetRetentionInDays":{"End":true,"Retry":[{"ErrorEquals":["CloudWatchLogs.CloudWatchLogsException","CloudWatchLogs.SdkClientException"],"IntervalSeconds":1,"MaxAttempts":5,"BackoffRate":2}],"Type":"Task","ResultPath":null,"Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -271,6 +218,37 @@ exports[`snapshot test 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
+                    "buildnotifymessageE60281A8",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "buildnotifymessageE60281A8",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "sqs:SendMessage",
+              "Effect": "Allow",
+              "Resource": "arn:aws:sqs:ap-northeast-1:123456789012:Queue",
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
                     "getlogstreamsD20145F9",
                     "Arn",
                   ],
@@ -318,37 +296,6 @@ exports[`snapshot test 1`] = `
               ],
             },
             {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "Eval41256dc5445742738ed917bc818694e54EB1134F",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "Eval41256dc5445742738ed917bc818694e54EB1134F",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "sqs:SendMessage",
-              "Effect": "Allow",
-              "Resource": "arn:aws:sqs:ap-northeast-1:123456789012:Queue",
-            },
-            {
               "Action": "logs:putRetentionPolicy",
               "Effect": "Allow",
               "Resource": "arn:aws:logs:*:*:log-group:*:*",
@@ -360,6 +307,91 @@ exports[`snapshot test 1`] = `
         "Roles": [
           {
             "Ref": "StateMachineRoleB840431D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "buildnotifymessageE60281A8": {
+      "DependsOn": [
+        "buildnotifymessageServiceRoleDefaultPolicy796E36E1",
+        "buildnotifymessageServiceRoleB8AA7954",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
+          },
+          "S3Key": "HASH-REPLACED.zip",
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "buildnotifymessageServiceRoleB8AA7954",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "Active",
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "buildnotifymessageServiceRoleB8AA7954": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "buildnotifymessageServiceRoleDefaultPolicy796E36E1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "buildnotifymessageServiceRoleDefaultPolicy796E36E1",
+        "Roles": [
+          {
+            "Ref": "buildnotifymessageServiceRoleB8AA7954",
           },
         ],
       },

--- a/test/build_notify_message.test.ts
+++ b/test/build_notify_message.test.ts
@@ -1,0 +1,93 @@
+import {
+  buildCloudWatchLogsUrl,
+  buildNotifyMessageLine,
+  handler,
+} from '../lib/clean_cloudwatch_logs-stack.build_notify_message'
+
+describe('buildNotifyMessageLine', () => {
+  test('空LogGroup1件分のメッセージ行を生成する', () => {
+    expect(buildNotifyMessageLine('ap-northeast-1', '/foo')).toBe(
+      'Region: ap-northeast-1, Loggroup: /foo is empty.'
+    )
+  })
+})
+
+describe('buildCloudWatchLogsUrl', () => {
+  test('ap-northeast-1 の CloudWatch Logs コンソール URL を生成する', () => {
+    expect(buildCloudWatchLogsUrl('ap-northeast-1')).toBe(
+      'https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups'
+    )
+  })
+
+  test('us-east-1 の CloudWatch Logs コンソール URL を生成する', () => {
+    expect(buildCloudWatchLogsUrl('us-east-1')).toBe(
+      'https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups'
+    )
+  })
+})
+
+describe('handler', () => {
+  test('空LogGroupが0件の場合は空文字を返す', async () => {
+    const result = await handler({
+      getLogStreamsResults: [
+        { logGroupName: '/foo', isEmpty: false, region: 'ap-northeast-1' },
+      ],
+    })
+
+    expect(result).toEqual({ notifyMessage: '' })
+  })
+
+  test('空LogGroupが1件の場合は1行メッセージとCloudWatch Logsリンクを返す', async () => {
+    const result = await handler({
+      getLogStreamsResults: [
+        { logGroupName: '/foo', isEmpty: true, region: 'ap-northeast-1' },
+      ],
+    })
+
+    expect(result).toEqual({
+      notifyMessage: [
+        'Region: ap-northeast-1, Loggroup: /foo is empty.',
+        buildCloudWatchLogsUrl('ap-northeast-1'),
+      ].join('\n'),
+    })
+  })
+
+  test('空LogGroupが複数件の場合は改行連結メッセージとCloudWatch Logsリンクを返す', async () => {
+    const result = await handler({
+      getLogStreamsResults: [
+        { logGroupName: '/foo', isEmpty: true, region: 'ap-northeast-1' },
+        { logGroupName: '/bar', isEmpty: false, region: 'ap-northeast-1' },
+        { logGroupName: '/baz', isEmpty: true, region: 'ap-northeast-1' },
+      ],
+    })
+
+    expect(result).toEqual({
+      notifyMessage: [
+        'Region: ap-northeast-1, Loggroup: /foo is empty.',
+        'Region: ap-northeast-1, Loggroup: /baz is empty.',
+        buildCloudWatchLogsUrl('ap-northeast-1'),
+      ].join('\n'),
+    })
+  })
+
+  test('getLogStreamsResultsが空配列の場合は空文字を返す', async () => {
+    const result = await handler({ getLogStreamsResults: [] })
+
+    expect(result).toEqual({ notifyMessage: '' })
+  })
+
+  test('入力が不正な場合は空文字を返す', async () => {
+    await expect(handler(null)).resolves.toEqual({ notifyMessage: '' })
+    await expect(handler({})).resolves.toEqual({ notifyMessage: '' })
+    await expect(handler({ getLogStreamsResults: 'invalid' })).resolves.toEqual({ notifyMessage: '' })
+    await expect(handler({
+      getLogStreamsResults: [{ logGroupName: '/foo', isEmpty: 'true', region: 'ap-northeast-1' }],
+    })).resolves.toEqual({ notifyMessage: '' })
+    await expect(handler({
+      getLogStreamsResults: [{ logGroupName: 123, isEmpty: true, region: 'ap-northeast-1' }],
+    })).resolves.toEqual({ notifyMessage: '' })
+    await expect(handler({
+      getLogStreamsResults: [{ logGroupName: '/foo', isEmpty: true, region: 123 }],
+    })).resolves.toEqual({ notifyMessage: '' })
+  })
+})


### PR DESCRIPTION
## Summary

- 空LogGroupごとにSQSへ通知していたStep Functionsフローを変更し、Map処理完了後に1件の通知メッセージへ集約する
- 通知メッセージ末尾にCloudWatch Logsコンソールへのリンクを追加する
- `build_notify_message` Lambda を新設し、空LogGroupが0件の場合はSQS通知をスキップするChoice分岐を追加する
- 新規Lambdaの単体テストおよびスナップショットテストを更新する

## Test plan

- [x] `npm test` で `build_notify_message.test.ts` および `snapshot.test.ts` がパスすること
- [ ] デプロイ後、空LogGroupが複数ある場合にSQS通知が1件にまとまること
- [ ] 通知メッセージにCloudWatch LogsコンソールURLが含まれること
- [ ] 空LogGroupが0件の場合にSQS通知が送信されないこと


Made with [Cursor](https://cursor.com)