### PR TITLE
LambdaのLogGroupをスタックリソースとして追加する

### DIFF
--- a/lib/clean_cloudwatch_logs-stack.ts
+++ b/lib/clean_cloudwatch_logs-stack.ts
@@ -7,6 +7,7 @@ import {
   aws_lambda as lambda,
   aws_lambda_nodejs as lambdaNodejs,
   aws_iam as iam,
+  aws_logs as logs,
   aws_sqs as sqs,
 } from 'aws-cdk-lib'
 import * as construct from 'constructs'
@@ -22,6 +23,25 @@ interface StackProps extends cdk.StackProps {
   queueArn: string;
 }
 
+export const lambdaFunctionNames = {
+  getLogGroups: 'get_log_groups',
+  getLogStreams: 'get_log_streams',
+  deleteLogStreams: 'delete_log_streams',
+  buildNotifyMessage: 'build_notify_message',
+} as const
+
+function createLambdaLogGroup (
+  scope: construct.Construct,
+  id: string,
+  functionName: string
+): logs.LogGroup {
+  return new logs.LogGroup(scope, id, {
+    logGroupName: `/aws/lambda/${functionName}`,
+    retention: logs.RetentionDays.ONE_MONTH,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  })
+}
+
 export class CleanCloudwatchLogsStack extends cdk.Stack {
   constructor (scope: construct.Construct, id: string, props: StackProps) {
     super(scope, id, props)
@@ -35,6 +55,8 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(1),
       tracing: lambda.Tracing.ACTIVE,
       runtime: lambda.Runtime.NODEJS_22_X,
+      functionName: lambdaFunctionNames.getLogGroups,
+      logGroup: createLambdaLogGroup(this, 'GetLogGroupsLogGroup', lambdaFunctionNames.getLogGroups),
     })
 
     getLogGroupsLambda.addToRolePolicy(new iam.PolicyStatement({
@@ -53,6 +75,8 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(5),
       tracing: lambda.Tracing.ACTIVE,
       runtime: lambda.Runtime.NODEJS_22_X,
+      functionName: lambdaFunctionNames.getLogStreams,
+      logGroup: createLambdaLogGroup(this, 'GetLogStreamsLogGroup', lambdaFunctionNames.getLogStreams),
     })
 
     getLogStreamsLambda.addToRolePolicy(new iam.PolicyStatement({
@@ -69,6 +93,8 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(15),
       tracing: lambda.Tracing.ACTIVE,
       runtime: lambda.Runtime.NODEJS_22_X,
+      functionName: lambdaFunctionNames.deleteLogStreams,
+      logGroup: createLambdaLogGroup(this, 'DeleteLogStreamsLogGroup', lambdaFunctionNames.deleteLogStreams),
     })
 
     deleteLogStreamsLambda.addToRolePolicy(new iam.PolicyStatement({
@@ -86,6 +112,8 @@ export class CleanCloudwatchLogsStack extends cdk.Stack {
       timeout: cdk.Duration.seconds(30),
       tracing: lambda.Tracing.ACTIVE,
       runtime: lambda.Runtime.NODEJS_22_X,
+      functionName: lambdaFunctionNames.buildNotifyMessage,
+      logGroup: createLambdaLogGroup(this, 'BuildNotifyMessageLogGroup', lambdaFunctionNames.buildNotifyMessage),
     })
 
     const buildNotifyMessage = new tasks.LambdaInvoke(this, 'BuildNotifyMessage', {

--- a/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/__snapshots__/snapshot.test.ts.snap
@@ -10,6 +10,98 @@ exports[`snapshot test 1`] = `
     },
   },
   "Resources": {
+    "BuildNotifyMessageLogGroup1F6700A3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/build_notify_message",
+        "RetentionInDays": 30,
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeleteLogStreamsLogGroupF423A89B": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/delete_log_streams",
+        "RetentionInDays": 30,
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "GetLogGroupsLogGroup1CD3D6E3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/get_log_groups",
+        "RetentionInDays": 30,
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "GetLogStreamsLogGroupB6942BE3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/get_log_streams",
+        "RetentionInDays": 30,
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "prod",
+          },
+          {
+            "Key": "ManagedBy",
+            "Value": "cdk",
+          },
+          {
+            "Key": "Project",
+            "Value": "clean_cloudwatch_logs",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
     "Schedule83A77FD1": {
       "Properties": {
         "FlexibleTimeWindow": {
@@ -369,7 +461,13 @@ exports[`snapshot test 1`] = `
           },
           "S3Key": "HASH-REPLACED.zip",
         },
+        "FunctionName": "build_notify_message",
         "Handler": "index.handler",
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "BuildNotifyMessageLogGroup1F6700A3",
+          },
+        },
         "Role": {
           "Fn::GetAtt": [
             "buildnotifymessageServiceRoleB8AA7954",
@@ -482,7 +580,13 @@ exports[`snapshot test 1`] = `
           },
           "S3Key": "HASH-REPLACED.zip",
         },
+        "FunctionName": "delete_log_streams",
         "Handler": "index.handler",
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "DeleteLogStreamsLogGroupF423A89B",
+          },
+        },
         "Role": {
           "Fn::GetAtt": [
             "deletelogstreamsServiceRole859AA330",
@@ -600,7 +704,13 @@ exports[`snapshot test 1`] = `
           },
           "S3Key": "HASH-REPLACED.zip",
         },
+        "FunctionName": "get_log_groups",
         "Handler": "index.handler",
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "GetLogGroupsLogGroup1CD3D6E3",
+          },
+        },
         "Role": {
           "Fn::GetAtt": [
             "getloggroupsServiceRole2F7300D4",
@@ -718,7 +828,13 @@ exports[`snapshot test 1`] = `
           },
           "S3Key": "HASH-REPLACED.zip",
         },
+        "FunctionName": "get_log_streams",
         "Handler": "index.handler",
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "GetLogStreamsLogGroupB6942BE3",
+          },
+        },
         "Role": {
           "Fn::GetAtt": [
             "getlogstreamsServiceRoleF2C01167",

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
-import { CleanCloudwatchLogsStack } from '../lib/clean_cloudwatch_logs-stack'
+import { CleanCloudwatchLogsStack, lambdaFunctionNames } from '../lib/clean_cloudwatch_logs-stack'
 
 export const ignoreAssetHashSerializer = {
   test: (val: unknown) => typeof val === 'string',
@@ -30,6 +30,18 @@ test('snapshot test', () => {
       Tags: Match.arrayWith([tag]),
     })
   }
+
+  template.resourceCountIs('AWS::Logs::LogGroup', 4)
+  for (const functionName of Object.values(lambdaFunctionNames)) {
+    template.hasResourceProperties('AWS::Logs::LogGroup', {
+      LogGroupName: `/aws/lambda/${functionName}`,
+      RetentionInDays: 30,
+    })
+  }
+  template.allResources('AWS::Logs::LogGroup', {
+    DeletionPolicy: 'Delete',
+    UpdateReplacePolicy: 'Delete',
+  })
 
   expect.addSnapshotSerializer(ignoreAssetHashSerializer)
 


### PR DESCRIPTION
## Summary
- 4つの Lambda 関数それぞれに `AWS::Logs::LogGroup` リソースを追加し、ログ出力先を CDK で管理するようにしました
- LogGroup 名を `/aws/lambda/<関数名>` 形式に統一し、Lambda 関数にも `functionName` を明示しました
- LogGroup の保持期間を 30 日に設定し、スタック削除時に LogGroup も一緒に削除されるよう `removalPolicy: DESTROY` を指定しました
- スナップショットテストに LogGroup の件数・名前・削除ポリシーの検証を追加しました

## Test plan
- [x] `npm test` がパスすること
- [ ] デプロイ後、各 Lambda のログが `/aws/lambda/<関数名>` の LogGroup に出力されること
- [ ] 既存環境へのデプロイ時、旧 LogGroup が残っていないか確認すること


Made with [Cursor](https://cursor.com)