### PR TITLE
chore: dependabot.ymlを新規追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 1
+      semver-patch-days: 1
+    groups:
+      aws-cdk:
+        patterns:
+          - "aws-cdk"
+          - "aws-cdk-lib"
+          - "constructs"
+          - "@aws-cdk/*"
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+          - "@smithy/*"
+          - "aws-sdk-client-mock"
+          - "aws-sdk-client-mock-vitest"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "neostandard"
+      types:
+        patterns:
+          - "@types/*"
+      typescript:
+        patterns:
+          - "typescript"
+          - "@tsconfig/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 1
+      semver-patch-days: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- このリポジトリにはDependabot設定(`.github/dependabot.yml`)が存在しなかったため新規追加
- 他リポジトリ(`nar_api`, `ses_to_slack`, `notify_horse_infos`)と同様に、`aws-cdk`/`aws-cdk-lib`/`constructs`をグループ化し、Cloud Assemblyスキーマのバージョン不整合([notify_horse_infos PR #33](https://github.com/masaminh/notify_horse_infos/pull/33)で発生した問題)の再発を防ぐ
- 実際の依存関係(`package.json`)に合わせて`aws-sdk`/`vitest`/`eslint`/`types`/`typescript`もグループ化
- `github-actions`エコシステムも追加し、`lighten_stack`を参考にActionsのminor/patch更新を1グループにまとめる(メジャー更新は個別PRのまま)

## Test plan
- [x] YAML構文を検証済み(`ruby -ryaml`)
- [ ] 次回のDependabot定期実行(weekly)で、グループ化されたPRが提案されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)